### PR TITLE
SQLFilter Hash

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -142,6 +142,18 @@ abstract class SQLFilter
     {
         return $this->em->getConnection();
     }
+    
+    /**
+     * Return a hash representation of this instance for e.g. caching id purposes.
+     * Defaults to __toString(). Can be overridden in case a custom SQLFilter
+     * needs to manipulate its caching behaviour.
+     *
+     * @return string A string representation as hash id
+     */
+    public function getHash()
+    {
+    	return $this->__toString();
+    }
 
     /**
      * Gets the SQL query part to add to a query.

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -209,7 +209,7 @@ class FilterCollection
         $filterHash = '';
 
         foreach ($this->enabledFilters as $name => $filter) {
-            $filterHash .= $name . $filter;
+            $filterHash .= $name . $filter->getHash();
         }
 
         return $filterHash;


### PR DESCRIPTION
To be more flexible from a custom SQLFilter perspective, a dedicated hash function was added, which is not final and can be used by any implementing class to manipulate its e.g. caching behaviour.